### PR TITLE
Implement plan_mdct and plan_imdct

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ where the last line computes the difference between the overlapped
 IMDCT sum and the original data, and should be around
 10<sup>&minus;15</sup> (floating-point roundoff error).
 
+## Planning
+
+To create a pre-planned transforms for a given size of input vector
+do:
+
+    using MDCT
+    Mp = plan_mdct(X)
+    Ip = plan_imdct(Y)
+
+where `Ip` and `Mp` are pre-planned transforms optimized to allow much
+quicker subsequent transformations. To use them simply:
+
+
+    Xt = Mp*X
+    Yt = Ip*Y
+
 ## Author
 
 This module was written by [Steven G. Johnson](http://math.mit.edu/~stevenj/).

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 Compat 0.59.0
 FFTW
+AbstractFFTs

--- a/src/MDCT.jl
+++ b/src/MDCT.jl
@@ -2,14 +2,18 @@ VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module MDCT
 using Compat
-export mdct, imdct
+using Compat.LinearAlgebra
+import AbstractFFTs
+export mdct, imdct, plan_mdct, plan_imdct
+import Base: *, size
+import Compat.LinearAlgebra.mul!
 
 if VERSION < v"0.7.0-DEV.602"
     using Base.FFTW
-    import Base.FFTW: fftwNumber, r2r, r2r!, REDFT11
+    import Base.FFTW: fftwNumber, r2r, r2r!, REDFT11, plan_r2r!, plan_r2r
 else
     using FFTW
-    import FFTW: fftwNumber, r2r, r2r!, REDFT11
+    import FFTW: fftwNumber, r2r, r2r!, REDFT11, plan_r2r!, plan_r2r
 end
 
 fftwsimilar(X::AbstractArray{T}, sz) where {T<:fftwNumber} = Array{T}(undef, sz...)
@@ -62,5 +66,61 @@ end
 
 imdct(X::AbstractVector{T}) where {T<:Number} =
     imdct(copy!(fftwsimilar(X, size(X)), X))
+
+mutable struct MDCTPlan{T<:fftwNumber, N, inv} <: AbstractFFTs.Plan{T}
+    plan::FFTW.r2rFFTWPlan{T} # plan_r2r! REDFT11 plan
+    pinv::AbstractFFTs.Plan{T}
+    MDCTPlan{T, N, inv}(plan) where {T, N, inv} = new(plan)
+end
+
+size(p::MDCTPlan{T, N, true}) where {T<:Number, N} = (div(N,2), N)
+size(p::MDCTPlan{T, N, false}) where {T<:Number, N} = (2*N, N)
+
+function mul!(Y::StridedArray{T}, p::MDCTPlan{T, N, false}, X::AbstractArray{T}) where {T<:Number, N}
+    @boundscheck (length(X) == 2*N && length(Y) == N) || throw(DimensionMismatch())
+    N2 = div(N,2)
+    @inbounds for i = 1:N2
+        Y[i] = -0.5 * (X[(3*N2+1)-i] + X[3*N2+i])
+        Y[N2+i] = -0.5 * (X[(2*N2+1)-i] - X[i])
+    end
+    return p.plan * Y
+end
+
+function mul!(Z::StridedArray{T}, p::MDCTPlan{T, N, true}, X::AbstractArray{T}) where {T<:Number, N}
+    @boundscheck length(Z) == N || throw(DimensionMismatch())
+    Y = p.plan*copy(X)
+    N1 = div(N,2)
+    N2 = div(N1,2)
+    s = 0.5 / N1
+    @inbounds for i = 1:N2
+        Z[N1+1-i] = -(Z[i] = Y[N2+i]*s)
+        Z[N1+N2+1-i] = (Z[N1+N2+i] = -Y[i]*s)
+    end
+    return Z
+end
+
+function *(p::MDCTPlan{T, N}, X::AbstractArray{T}) where {T<:Number, N}
+    Y = fftwsimilar(X, N)
+    return mul!(Y, p, X)
+end
+
+function plan_mdct(X::AbstractVector{T}) where {T<:Number}
+    sz = length(X)
+    if mod(sz, 4) != 0
+        throw(ArgumentError("mdct requires a multiple-of-4 vector length"))
+        # FIXME: handle odd case via DCT-III?
+    end
+    N = div(sz, 2);
+    return MDCTPlan{T, N, false}(plan_r2r!(view(X, 1:N), REDFT11))
+end
+
+function plan_imdct(X::AbstractVector{T}) where {T<:Number}
+    sz = length(X)
+    if isodd(sz)
+        throw(ArgumentError("imdct requires an even vector length"))
+        # FIXME: handle odd case via DCT-II?
+    end
+    return MDCTPlan{T, 2*sz, true}(plan_r2r!(X, REDFT11))
+end
 
 end # MDCT

--- a/src/MDCT.jl
+++ b/src/MDCT.jl
@@ -10,10 +10,10 @@ import Compat.LinearAlgebra.mul!
 
 if VERSION < v"0.7.0-DEV.602"
     using Base.FFTW
-    import Base.FFTW: fftwNumber, r2r, r2r!, REDFT11, plan_r2r!
+    import Base.FFTW: fftwNumber, r2r, r2r!, REDFT11, plan_r2r!, plan_r2r
 else
     using FFTW
-    import FFTW: fftwNumber, r2r, r2r!, REDFT11, plan_r2r!
+    import FFTW: fftwNumber, r2r, r2r!, REDFT11, plan_r2r!, plan_r2r
 end
 
 fftwsimilar(X::AbstractArray{T}, sz) where {T<:fftwNumber} = Array{T}(undef, sz...)
@@ -86,9 +86,9 @@ function mul!(Y::StridedVector{T}, p::Plan{T, N, false}, X::AbstractVector{T}) w
     return p.plan * Y
 end
 
-function mul!(Z::StridedVector{T}, p::Plan{T, N, true}, X::AbstractVector{T}) where {T<:Number, N}
+function mul!(Z::StridedVector{T}, p::Plan{T, N, true}, X::StridedVector{T}) where {T<:Number, N}
     @boundscheck length(Z) == N || throw(DimensionMismatch())
-    Y = p.plan*copy(X)
+    Y = p.plan*X
     N1 = div(N,2)
     N2 = div(N1,2)
     s = 0.5 / N1
@@ -120,7 +120,7 @@ function plan_imdct(X::AbstractVector{T}, flags::Integer=FFTW.ESTIMATE, timelimi
         throw(ArgumentError("imdct requires an even vector length"))
         # FIXME: handle odd case via DCT-II?
     end
-    return Plan{T, 2sz, true}(plan_r2r!(fftwsimilar(X, sz), REDFT11; flags=flags, timelimit=timelimit))
+    return Plan{T, 2sz, true}(plan_r2r(fftwsimilar(X, sz), REDFT11; flags=flags, timelimit=timelimit))
 end
 
 end # MDCT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,11 +23,16 @@ function slow_imdct(y::AbstractVector{T}) where {T<:Number}
     return x
 end
 
-N=100
-X = rand(N)
-Y = mdct(X)
-Z = imdct(Y)
-Ys = slow_mdct(X)
-Zs = slow_imdct(Y)
-@test Y ≈ Ys rtol=1e-13
-@test Z ≈ Zs rtol=1e-13
+for N=100:4:108
+    X = rand(N)
+    Y = mdct(X)
+    Z = imdct(Y)
+    Yp = plan_mdct(X)*X
+    Zp = plan_imdct(Y)*Y
+    Ys = slow_mdct(X)
+    Zs = slow_imdct(Y)
+    @test Y ≈ Ys rtol=1e-13
+    @test Z ≈ Zs rtol=1e-13
+    @test Yp ≈ Ys rtol=1e-13
+    @test Zp ≈ Zs rtol=1e-13
+end


### PR DESCRIPTION
These two functions return specialized function for computing MDCT (or IMDCT) on an input array of known length (similar to `FFTW.plan_dct`). I based the implementation on [this paper](https://pdfs.semanticscholar.org/2f26/a658836927331d559e723ac36b8dab911b14.pdf). Using the pre-planned functions is around 10 times faster on my PC than the not pre-planned versions.